### PR TITLE
Fixed Bug #1

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -5,6 +5,7 @@ const theButtons = document.querySelectorAll("#buttonHolder img");
 const puzzleBoard = document.querySelector(".puzzle-board");
 const puzzlePieces = document.querySelectorAll(".puzzle-pieces img");
 const dropZones = document.querySelectorAll(".drop-zone");
+const puzzlePieceDiv = document.querySelector(".puzzle-pieces")
 let draggedPiece;
 
 // functions
@@ -24,7 +25,12 @@ function handleOver(e) {
 }
 
 function handleDrop() {
-    this.appendChild(draggedPiece);
+    // Here is where the fix for bug #1 will come — we will add an if/else statement so the piece can't be dropped if there is already one filling it.
+    if (this.childNodes.length > 0) {
+        return; // If there's already a child in the drop zone, do nothing = don't allow it to be dropped.
+    } else {
+        this.appendChild(draggedPiece); // Otherwise, append the dragged piece.
+    }
 }
 
 // events


### PR DESCRIPTION
In this commit, the bug 1 was fixed by putting an "if, else" statement inside the handleDrop function, that checks if the drop zone has any child nodes already in it (this.childNodes.length > 0). If it is already filled, the function returns and doesn't allow the drop. If the drop zone is empty, it allows the drop.