### PR TITLE
Fixed Bug #2

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -12,6 +12,9 @@ let draggedPiece;
 function changeBGImage(event) {
     console.log(event.currentTarget.id);
     puzzleBoard.style.backgroundImage = `url('./images/backGround${event.currentTarget.id}.jpg')`;
+
+    // Here is where the fix for bug #2 will come — we will add a forEach loop that goes over all puzzle pieces and append them back to their original div.
+    puzzlePieces.forEach(piece => puzzlePieceDiv.appendChild(piece));
 }
 
 function handleStartDrag() {


### PR DESCRIPTION
In this commit, bug #2 was fixed by  including a new variable that sets the original placement for the puzzlePiece divisory. After that, I included a "forEach" loop inside the changeBGimage function that goes over all puzzle pieces and appends them back to puzzlePieceDiv (original placement).